### PR TITLE
Extract ceramics card image transition to CSS class

### DIFF
--- a/pages/ceramics/index.tsx
+++ b/pages/ceramics/index.tsx
@@ -49,10 +49,7 @@ export default function CeramicsLanding() {
                     alt={series.title}
                     fill
                     sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                    style={{
-                      objectFit: "cover",
-                      transition: "transform 400ms cubic-bezier(.2,.8,.2,1)",
-                    }}
+                    style={{ objectFit: "cover" }}
                     className="ceramics-card-img"
                     priority={i < 3}
                   />

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -21,12 +21,13 @@ function ProjectCardImage({ item }: { item: ProjectEntry }) {
         alt={item.title}
         fill
         style={{ objectFit: "cover" }}
+        className="ceramics-card-img"
       />
     );
   }
   const grad = `linear-gradient(135deg, ${item.color} 0%, ${shade(item.color, -30)} 100%)`;
   return (
-    <div style={{ position: "absolute", inset: 0, background: grad }}>
+    <div className="ceramics-card-img" style={{ position: "absolute", inset: 0, background: grad }}>
       <svg
         width="100%"
         height="100%"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -342,6 +342,9 @@ hgroup {
   flex-direction: column;
   gap: 16px;
 }
+.ceramics-card-img {
+  transition: transform 400ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
 .ceramics-card-img:hover {
   transform: scale(1.02);
 }


### PR DESCRIPTION
## Summary
Refactored the transition animation for ceramics card images from inline styles to a dedicated CSS class for better maintainability and consistency across components.

## Key Changes
- Moved the `transition: transform 400ms cubic-bezier(0.2, 0.8, 0.2, 1)` style from inline styles in `pages/ceramics/index.tsx` to a new `.ceramics-card-img` CSS class in `styles/globals.css`
- Applied the `.ceramics-card-img` class to the image element in `pages/ceramics/index.tsx`, removing the inline transition style
- Applied the `.ceramics-card-img` class to the gradient overlay div in `pages/projects.tsx` for consistent hover animation behavior
- Simplified the inline style in `pages/ceramics/index.tsx` to only include `objectFit: "cover"`

## Implementation Details
The transition animation is now centralized in the global stylesheet, making it easier to maintain and ensuring consistent behavior across all ceramics card images. The hover scale effect (already defined in the existing `:hover` rule) now applies to both image and gradient elements through the shared class.

https://claude.ai/code/session_019RKMiTkbNrPM6wrmcoQNNw