### PR TITLE
chore: add CLAUDE.md with dev workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Dev Workflow
+
+## Package scripts
+Run all linting, formatting, building, and testing through the scripts defined in `package.json`. Do not invoke tools like `eslint`, `prettier`, `vitest`, or `next` directly.
+
+Available scripts:
+- `yarn dev` — start dev server
+- `yarn build` — production build
+- `yarn lint` / `yarn lint:fix` — ESLint
+- `yarn format` / `yarn format:check` — Prettier
+- `yarn test` / `yarn test:watch` / `yarn test:coverage` — Vitest
+
+## Package manager
+Always use **yarn**. Never use `npm` or `npx`.
+
+## Before pushing
+Before pushing any branch or creating a PR, always run the following in order and fix any failures before proceeding:
+
+1. `yarn lint` — fix any ESLint errors (use `yarn lint:fix` to auto-fix)
+2. `yarn format:check` — fix any formatting issues (use `yarn format` to auto-fix)
+3. `yarn test` — confirm all tests pass
+4. `yarn build` — confirm the production build succeeds
+
+Do not push if any of these commands fail.
+
+## Branch naming
+Branches must follow the pattern: `<type>/<3-5 word kebab-case description>`
+
+Valid types: `feature`, `chore`, `fix`
+
+Examples:
+- `feature/add-ceramics-gallery`
+- `fix/logo-icon-extension`
+- `chore/update-dependencies`


### PR DESCRIPTION
## Summary
- Establishes yarn as the only package manager (no npm/npx)
- Requires all linting, formatting, building, and testing to go through `package.json` scripts
- Adds a pre-push checklist: lint → format:check → test → build, all must pass before pushing
- Defines branch naming convention: `<feature|chore|fix>/<3-5 word kebab-case description>`

## Test plan
- [ ] Verify `CLAUDE.md` appears at the repo root after merge
- [ ] Open a new Claude Code session and confirm it follows the yarn/script rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)