### PR TITLE
feat: add optional order field for grid position on projects and ceramics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,13 @@ Available scripts:
 ## Package manager
 Always use **yarn**. Never use `npm` or `npx`.
 
+## Worktree setup
+When starting work in a new worktree:
+
+1. `git pull` on the base branch before creating the worktree so it includes the latest commits (including this file)
+2. Run `yarn install` inside the worktree immediately after entering it — git worktrees do not include `node_modules`, so yarn commands will fail without this step
+3. Run all checks (`yarn lint`, `yarn format:check`, `yarn test`, `yarn build`) from inside the worktree, never from the main project directory
+
 ## Before pushing
 Before pushing any branch or creating a PR, always run the following in order and fix any failures before proceeding:
 

--- a/content/projects/desktop-photography.md
+++ b/content/projects/desktop-photography.md
@@ -1,5 +1,6 @@
 ---
 title: Desktop Photography
+order: 2
 year: Ongoing
 kind: Design
 blurb: An ongoing effort of cataloging the places I've been in a few images I can see every day.

--- a/content/projects/electrolink-paper.md
+++ b/content/projects/electrolink-paper.md
@@ -1,5 +1,6 @@
 ---
 title: Electrolink Paper
+order: 1
 year: 2025
 kind: Design
 blurb: A full layout and branding design project.

--- a/content/projects/irrigation-controller.md
+++ b/content/projects/irrigation-controller.md
@@ -1,5 +1,6 @@
 ---
 title: Irrigation Controller
+order: 0
 year: 2021-current
 kind: Project
 blurb: A long term project to replace our old dumb controller with something that I could control through Home Assistant.

--- a/pages/ceramics/index.tsx
+++ b/pages/ceramics/index.tsx
@@ -4,6 +4,15 @@ import Link from "next/link";
 import UniversalHeaderBar from "../../src/Components/UniversalHeaderBar";
 import { CERAMICS_SERIES } from "../../src/data/ceramics";
 
+const sortedSeries = [...CERAMICS_SERIES].sort((a, b) => {
+  const aHasOrder = a.order !== undefined;
+  const bHasOrder = b.order !== undefined;
+  if (aHasOrder && bHasOrder) return a.order! - b.order!;
+  if (aHasOrder) return -1;
+  if (bHasOrder) return 1;
+  return 0;
+});
+
 export default function CeramicsLanding() {
   return (
     <div className="page-shell">
@@ -35,7 +44,7 @@ export default function CeramicsLanding() {
 
       <section className="ceramics-grid-section">
         <div className="ceramics-grid">
-          {CERAMICS_SERIES.map((series, i) => (
+          {sortedSeries.map((series, i) => (
             <article key={series.slug} className="ceramics-card">
               <Link href={`/ceramics/${series.slug}`} style={{ display: "block" }}>
                 <div

--- a/src/data/ceramics.ts
+++ b/src/data/ceramics.ts
@@ -6,6 +6,7 @@ export interface Photo {
 
 export interface Series {
   slug: string;
+  order?: number;
   title: string;
   material: string;
   year: string;

--- a/src/data/ceramics.ts
+++ b/src/data/ceramics.ts
@@ -19,6 +19,7 @@ export interface Series {
 export const CERAMICS_SERIES: Series[] = [
   {
     slug: "espresso-mugs-01",
+    order: 0,
     title: "Espresso Mugs",
     material: "stonewear (LBC)",
     status: "complete",
@@ -64,6 +65,7 @@ export const CERAMICS_SERIES: Series[] = [
   },
   {
     slug: "taped-mugs-01",
+    order: 1,
     title: "Taped Tea Mugs",
     material: "stonewear (LBC)",
     status: "complete",
@@ -129,6 +131,7 @@ export const CERAMICS_SERIES: Series[] = [
   },
   {
     slug: "ramen-bowls-02",
+    order: 2,
     title: "Ramen Bowls",
     material: "porcelain",
     status: "complete",
@@ -179,6 +182,7 @@ export const CERAMICS_SERIES: Series[] = [
   },
   {
     slug: "misc-pieces",
+    order: 3,
     title: "Misc Pieces",
     material: "various",
     year: "2023-2026",

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -7,6 +7,7 @@ export interface GalleryPhoto {
 
 export interface ProjectEntry {
   slug: string;
+  order?: number;
   year: number;
   kind: string;
   title: string;

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -7,14 +7,16 @@ const CONTENT_DIR = path.join(process.cwd(), "content/projects");
 
 export function getAllProjects(): ProjectEntry[] {
   const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".md"));
-  return files.map((filename) => parseProjectFile(filename)).sort((a, b) => {
-    const aHasOrder = a.order !== undefined;
-    const bHasOrder = b.order !== undefined;
-    if (aHasOrder && bHasOrder) return a.order! - b.order!;
-    if (aHasOrder) return -1;
-    if (bHasOrder) return 1;
-    return b.year - a.year;
-  });
+  return files
+    .map((filename) => parseProjectFile(filename))
+    .sort((a, b) => {
+      const aHasOrder = a.order !== undefined;
+      const bHasOrder = b.order !== undefined;
+      if (aHasOrder && bHasOrder) return a.order! - b.order!;
+      if (aHasOrder) return -1;
+      if (bHasOrder) return 1;
+      return b.year - a.year;
+    });
 }
 
 export function getProjectBySlug(slug: string): ProjectEntry | null {

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -7,7 +7,14 @@ const CONTENT_DIR = path.join(process.cwd(), "content/projects");
 
 export function getAllProjects(): ProjectEntry[] {
   const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".md"));
-  return files.map((filename) => parseProjectFile(filename)).sort((a, b) => b.year - a.year);
+  return files.map((filename) => parseProjectFile(filename)).sort((a, b) => {
+    const aHasOrder = a.order !== undefined;
+    const bHasOrder = b.order !== undefined;
+    if (aHasOrder && bHasOrder) return a.order! - b.order!;
+    if (aHasOrder) return -1;
+    if (bHasOrder) return 1;
+    return b.year - a.year;
+  });
 }
 
 export function getProjectBySlug(slug: string): ProjectEntry | null {
@@ -29,6 +36,7 @@ function parseProjectFile(filename: string): ProjectEntry {
   const { data, content } = matter(raw);
   return {
     slug,
+    ...(data.order !== undefined ? { order: data.order } : {}),
     year: data.year ?? 0,
     kind: data.kind ?? "",
     title: data.title ?? "",

--- a/src/test/lib/projects.test.ts
+++ b/src/test/lib/projects.test.ts
@@ -16,12 +16,12 @@ vi.mock("fs", () => {
 
 const mockFs = vi.mocked(fs);
 
-const FAKE_MD = (year: number, title: string) => `---
+const FAKE_MD = (year: number, title: string, order?: number) => `---
 title: ${title}
 year: ${year}
 kind: Engineering
 blurb: A test project
-color: "#FF0000"
+color: "#FF0000"${order !== undefined ? `\norder: ${order}` : ""}
 cover:
   src: https://example.com/cover.jpg
 gallery:
@@ -58,6 +58,52 @@ describe("getAllProjects", () => {
     expect(projects[0].year).toBe(2023);
     expect(projects[1].title).toBe("Alpha");
     expect(projects[1].year).toBe(2021);
+  });
+
+  it("sorts ordered projects before unordered ones", () => {
+    mockFs.readdirSync.mockReturnValue(["alpha.md", "beta.md", "gamma.md"] as never);
+    mockFs.readFileSync
+      .mockReturnValueOnce(FAKE_MD(2023, "Alpha") as never)
+      .mockReturnValueOnce(FAKE_MD(2020, "Beta", 1) as never)
+      .mockReturnValueOnce(FAKE_MD(2022, "Gamma", 0) as never);
+
+    const projects = getAllProjects();
+
+    expect(projects[0].title).toBe("Gamma");
+    expect(projects[1].title).toBe("Beta");
+    expect(projects[2].title).toBe("Alpha");
+  });
+
+  it("sorts ordered projects by order ascending", () => {
+    mockFs.readdirSync.mockReturnValue(["a.md", "b.md", "c.md"] as never);
+    mockFs.readFileSync
+      .mockReturnValueOnce(FAKE_MD(2023, "A", 2) as never)
+      .mockReturnValueOnce(FAKE_MD(2023, "B", 0) as never)
+      .mockReturnValueOnce(FAKE_MD(2023, "C", 1) as never);
+
+    const projects = getAllProjects();
+
+    expect(projects[0].title).toBe("B");
+    expect(projects[1].title).toBe("C");
+    expect(projects[2].title).toBe("A");
+  });
+
+  it("reads order from frontmatter", () => {
+    mockFs.readdirSync.mockReturnValue(["project.md"] as never);
+    mockFs.readFileSync.mockReturnValue(FAKE_MD(2022, "Ordered", 3) as never);
+
+    const [project] = getAllProjects();
+
+    expect(project.order).toBe(3);
+  });
+
+  it("leaves order undefined when not in frontmatter", () => {
+    mockFs.readdirSync.mockReturnValue(["project.md"] as never);
+    mockFs.readFileSync.mockReturnValue(FAKE_MD(2022, "No Order") as never);
+
+    const [project] = getAllProjects();
+
+    expect(project.order).toBeUndefined();
   });
 
   it("filters out non-markdown files", () => {


### PR DESCRIPTION
## Summary

- Adds optional `order` field to `ProjectEntry` and `Series` interfaces
- Projects: set `order: 0` (or any number) in a `.md` file's frontmatter to pin it to that grid position
- Ceramics: add `order: 0` to a series object in `ceramics.ts` to do the same
- Lower number = closer to the front of the grid; items without `order` sort after all ordered items using the existing defaults (year desc for projects, array position for ceramics)

## Test plan

- [x] Add `order: 0` to one project's frontmatter and confirm it appears first on `/projects`
- [x] Add `order: 0` to a ceramics series and confirm it appears first on `/ceramics`
- [x] Confirm items without `order` still sort correctly after ordered ones
- [x] `yarn test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)