### PR TITLE
fix: restore nav-pill active-state padding

### DIFF
--- a/src/Components/Pill.jsx
+++ b/src/Components/Pill.jsx
@@ -1,13 +1,16 @@
+const HEIGHT_CLASSES = { 4: "h-4", 8: "h-8", 10: "h-10", 12: "h-12" };
+
 export default function Pill({ link, h = 4, children, isDisabled = false, isActive = false }) {
+  const heightClass = HEIGHT_CLASSES[h] ?? "h-4";
   if (isDisabled) {
     return (
-      <div className={`object-contain flex-none h-${h} w-fit header-cat`}>
+      <div className={`object-contain flex-none ${heightClass} w-fit header-cat`}>
         <div className="nav-pill disabled">{children}</div>
       </div>
     );
   } else {
     return (
-      <a href={link} className={`object-contain flex-none h-${h} w-fit header-cat`}>
+      <a href={link} className={`object-contain flex-none ${heightClass} w-fit header-cat`}>
         <div className="nav-pill" data-active={isActive ? "true" : undefined}>
           {children}
         </div>

--- a/src/Components/UniversalHeaderBar.jsx
+++ b/src/Components/UniversalHeaderBar.jsx
@@ -1,7 +1,5 @@
-"use client";
-
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { useRouter } from "next/router";
 import Pill from "./Pill";
 import LogoIcon from "./LogoIcon";
 
@@ -11,7 +9,7 @@ const defaultElements = [
 ];
 
 export default function UniversalHeaderBar({ children = null }) {
-  const pathname = usePathname();
+  const { pathname } = useRouter();
 
   return (
     <div className="p-4 w-fit flex gap-8 flex-wrap">

--- a/src/test/components/UniversalHeaderBar.test.tsx
+++ b/src/test/components/UniversalHeaderBar.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import UniversalHeaderBar from "../../Components/UniversalHeaderBar";
-import { usePathname } from "next/navigation";
+import { useRouter } from "next/router";
 
-vi.mock("next/navigation", () => ({
-  usePathname: vi.fn(() => "/"),
+vi.mock("next/router", () => ({
+  useRouter: vi.fn(() => ({ pathname: "/" })),
 }));
 
 vi.mock("next/link", async () => {
@@ -13,7 +13,7 @@ vi.mock("next/link", async () => {
 });
 
 beforeEach(() => {
-  vi.mocked(usePathname).mockReturnValue("/");
+  vi.mocked(useRouter).mockReturnValue({ pathname: "/" } as ReturnType<typeof useRouter>);
 });
 
 describe("UniversalHeaderBar", () => {
@@ -41,7 +41,7 @@ describe("UniversalHeaderBar", () => {
   });
 
   it("marks the active nav item when pathname matches", () => {
-    vi.mocked(usePathname).mockReturnValue("/projects");
+    vi.mocked(useRouter).mockReturnValue({ pathname: "/projects" } as ReturnType<typeof useRouter>);
     render(<UniversalHeaderBar />);
 
     const projectsPill = screen.getByText("PROJECTS").closest(".nav-pill");


### PR DESCRIPTION
## Summary

- Replace `usePathname` from `next/navigation` (App Router API) with `useRouter` from `next/router` in `UniversalHeaderBar.jsx` — the App Router hook returns `null` in this Pages Router project, so `isActive` was never `true` and the active-state padding/background never appeared on the current page's button
- Remove the stray `"use client"` directive, which is an App Router concept and has no effect in the Pages Router
- Replace the dynamic `h-\${h}` Tailwind class in `Pill.jsx` with a static lookup map so Tailwind's scanner always sees complete class strings (`h-4`, `h-8`, etc.) and cannot silently drop them
- Update `UniversalHeaderBar.test.tsx` to mock `next/router` instead of `next/navigation`

## Test plan

- [ ] Visit `/projects` — PROJECTS button should show black background + padding
- [ ] Visit `/ceramics` — CERAMICS button should show black background + padding
- [ ] Hover over an inactive button — should still animate in with padding on hover
- [ ] All 60 unit tests pass (`yarn test`)
- [ ] Build succeeds (`yarn build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)