### PR TITLE
chore: consolidate typography into 10-style canonical scale

### DIFF
--- a/app/ceramics/[slug]/SeriesDetailClient.tsx
+++ b/app/ceramics/[slug]/SeriesDetailClient.tsx
@@ -55,18 +55,7 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
           <span className="arrow-left">←</span> All series
         </Link>
         <span style={{ color: "var(--color-placeholder)", fontSize: 12 }}>/</span>
-        <span
-          style={{
-            fontFamily: "var(--font-display)",
-            fontWeight: 700,
-            fontSize: 12,
-            color: "var(--color-ink)",
-            letterSpacing: "0.08em",
-            textTransform: "uppercase",
-          }}
-        >
-          {series.title}
-        </span>
+        <span className="t-btn">{series.title}</span>
       </div>
 
       {/* Hero */}
@@ -144,6 +133,7 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
               {series.photos.length > 5 && (
                 <a
                   href="#gallery"
+                  className="t-btn"
                   style={{
                     aspectRatio: "1/1",
                     background: "var(--color-surface)",
@@ -151,9 +141,6 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
                     borderRadius: 6,
                     display: "grid",
                     placeItems: "center",
-                    fontFamily: "var(--font-display)",
-                    fontWeight: 700,
-                    fontSize: 13,
                     color: "var(--color-ink-muted)",
                     textDecoration: "none",
                   }}
@@ -168,33 +155,14 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
         {/* Right: info */}
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           {(series.year || series.status === "in-progress") && (
-            <span
-              style={{
-                fontFamily: "var(--font-body)",
-                fontStyle: "italic",
-                fontSize: 10,
-                color: "var(--color-ink-muted)",
-                textTransform: "uppercase",
-                letterSpacing: "0.12em",
-              }}
-            >
+            <span className="t-microlabel">
               {series.year ? `Series · ${series.year}` : "Series"}
               {series.status === "in-progress" && (
                 <span style={{ color: "var(--color-coral)" }}> · In progress</span>
               )}
             </span>
           )}
-          <h1
-            style={{
-              fontFamily: "var(--font-display)",
-              fontWeight: 700,
-              fontSize: "clamp(40px, 4vw, 56px)",
-              lineHeight: 1,
-              color: "var(--color-ink-true)",
-              letterSpacing: "-0.025em",
-              margin: 0,
-            }}
-          >
+          <h1 className="t-header" style={{ margin: 0 }}>
             {series.title}
           </h1>
           <span
@@ -208,15 +176,7 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
             }}
           />
           {series.tagline && (
-            <p
-              style={{
-                fontFamily: "var(--font-body)",
-                fontSize: 18,
-                lineHeight: 1.55,
-                color: "var(--color-ink)",
-                margin: "4px 0 8px",
-              }}
-            >
+            <p className="t-lead" style={{ margin: "4px 0 8px" }}>
               {series.tagline}
             </p>
           )}
@@ -242,27 +202,10 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
                   alignItems: "baseline",
                 }}
               >
-                <dt
-                  style={{
-                    fontFamily: "var(--font-display)",
-                    fontWeight: 700,
-                    fontSize: 10,
-                    color: "var(--color-ink-muted)",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.12em",
-                    margin: 0,
-                  }}
-                >
+                <dt className="t-microlabel" style={{ margin: 0 }}>
                   {dt}
                 </dt>
-                <dd
-                  style={{
-                    fontFamily: "var(--font-body)",
-                    fontSize: 14,
-                    color: "var(--color-ink)",
-                    margin: 0,
-                  }}
-                >
+                <dd className="t-body" style={{ margin: 0 }}>
                   {dd}
                 </dd>
               </div>
@@ -271,16 +214,13 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
 
           <a
             href="#gallery"
+            className="t-btn"
             style={{
               alignSelf: "flex-start",
               background: "var(--color-ink)",
               color: "#FFFFFF",
               borderRadius: 10,
-              fontFamily: "var(--font-display)",
-              fontWeight: 700,
-              fontSize: 13,
               textTransform: "uppercase",
-              letterSpacing: "0.06em",
               padding: "14px 22px",
               textDecoration: "none",
               marginTop: 16,
@@ -296,29 +236,8 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
       {series.content && (
         <section className="series-description">
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            <span
-              style={{
-                fontFamily: "var(--font-body)",
-                fontStyle: "italic",
-                fontSize: 10,
-                color: "var(--color-ink-muted)",
-                textTransform: "uppercase",
-                letterSpacing: "0.12em",
-              }}
-            >
-              About this series
-            </span>
-            <h2
-              style={{
-                fontFamily: "var(--font-display)",
-                fontWeight: 700,
-                fontSize: "clamp(24px, 3vw, 32px)",
-                lineHeight: 1.05,
-                color: "var(--color-ink-true)",
-                letterSpacing: "-0.02em",
-                margin: 0,
-              }}
-            >
+            <span className="t-microlabel">About this series</span>
+            <h2 className="t-h2" style={{ margin: 0 }}>
               How it was made
             </h2>
           </div>
@@ -327,15 +246,7 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
               remarkPlugins={[remarkGfm]}
               components={{
                 p: ({ children }) => (
-                  <p
-                    style={{
-                      fontFamily: "var(--font-body)",
-                      fontSize: 16,
-                      lineHeight: 1.7,
-                      color: "var(--color-ink)",
-                      margin: 0,
-                    }}
-                  >
+                  <p className="t-body" style={{ margin: 0 }}>
                     {children}
                   </p>
                 ),
@@ -358,44 +269,14 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
           }}
         >
           <div>
-            <span
-              style={{
-                fontFamily: "var(--font-body)",
-                fontStyle: "italic",
-                fontSize: 10,
-                color: "var(--color-ink-muted)",
-                textTransform: "uppercase",
-                letterSpacing: "0.12em",
-                display: "block",
-                marginBottom: 6,
-              }}
-            >
+            <span className="t-microlabel" style={{ display: "block", marginBottom: 6 }}>
               Gallery
             </span>
-            <h2
-              style={{
-                fontFamily: "var(--font-display)",
-                fontWeight: 700,
-                fontSize: "clamp(24px, 3vw, 32px)",
-                lineHeight: 1.05,
-                color: "var(--color-ink-true)",
-                letterSpacing: "-0.02em",
-                margin: 0,
-              }}
-            >
+            <h2 className="t-h2" style={{ margin: 0 }}>
               {series.photos.length} photos
             </h2>
           </div>
-          <span
-            style={{
-              fontFamily: "var(--font-body)",
-              fontStyle: "italic",
-              fontSize: 12,
-              color: "var(--color-ink-muted)",
-            }}
-          >
-            Click any photo to enlarge
-          </span>
+          <span className="t-caption">Click any photo to enlarge</span>
         </div>
 
         <div ref={galleryRef} className="series-gallery-grid">
@@ -431,17 +312,7 @@ export default function SeriesDetailClient({ series }: { series: Series }) {
                 />
               </a>
               <figcaption style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
-                <span
-                  style={{
-                    fontFamily: "var(--font-display)",
-                    fontWeight: 700,
-                    fontSize: 10,
-                    color: "var(--color-ink-muted)",
-                    letterSpacing: "0.12em",
-                  }}
-                >
-                  {String(i + 1).padStart(2, "0")}
-                </span>
+                <span className="t-microlabel">{String(i + 1).padStart(2, "0")}</span>
               </figcaption>
             </figure>
           ))}

--- a/app/ceramics/page.tsx
+++ b/app/ceramics/page.tsx
@@ -63,70 +63,30 @@ export default function CeramicsLanding() {
                     gap: 16,
                   }}
                 >
-                  <h2
-                    style={{
-                      fontFamily: "var(--font-display)",
-                      fontWeight: 700,
-                      fontSize: 24,
-                      lineHeight: 1,
-                      color: "var(--color-ink-true)",
-                      letterSpacing: "-0.01em",
-                      margin: 0,
-                    }}
-                  >
+                  <h2 className="t-card-title" style={{ margin: 0 }}>
                     {s.title}
                   </h2>
                   {s.year && (
-                    <span
-                      style={{
-                        fontFamily: "var(--font-body)",
-                        fontStyle: "italic",
-                        fontSize: 12,
-                        color: "var(--color-ink-muted)",
-                        textTransform: "uppercase",
-                        letterSpacing: "0.06em",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
+                    <span className="t-microlabel" style={{ whiteSpace: "nowrap" }}>
                       {s.year}
                     </span>
                   )}
                 </div>
                 {s.material && (
-                  <span
-                    style={{
-                      fontFamily: "var(--font-body)",
-                      fontSize: 12,
-                      color: "var(--color-ink-muted)",
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                    }}
-                  >
+                  <span className="t-microlabel">
                     {s.material} · {s.photos.length} photos
                   </span>
                 )}
                 {s.tagline && (
-                  <p
-                    style={{
-                      fontFamily: "var(--font-body)",
-                      fontSize: 14,
-                      lineHeight: 1.55,
-                      color: "var(--color-ink)",
-                      margin: 0,
-                    }}
-                  >
+                  <p className="t-body" style={{ margin: 0 }}>
                     {s.tagline}
                   </p>
                 )}
                 <Link
                   href={`/ceramics/${s.slug}`}
-                  className="arrow-link"
+                  className="t-btn arrow-link"
                   style={{
                     alignSelf: "flex-start",
-                    fontFamily: "var(--font-display)",
-                    fontWeight: 700,
-                    fontSize: 13,
-                    color: "var(--color-ink)",
                     textDecoration: "underline",
                     textUnderlineOffset: 3,
                   }}

--- a/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/app/projects/[slug]/ProjectDetailClient.tsx
@@ -68,16 +68,11 @@ function BackLink() {
   return (
     <Link
       href="/projects"
-      className="arrow-link"
+      className="t-btn arrow-link"
       style={{
         display: "inline-flex",
         alignItems: "center",
         gap: 8,
-        fontFamily: "var(--font-display)",
-        fontWeight: 700,
-        fontSize: 12,
-        letterSpacing: "0.06em",
-        textTransform: "uppercase" as const,
         color: "var(--color-ink-muted)",
         textDecoration: "none",
         width: "fit-content",
@@ -285,19 +280,7 @@ function GalleryThumb({
           />
         </div>
       )}
-      {photo.caption && (
-        <figcaption
-          style={{
-            fontFamily: "var(--font-body)",
-            fontStyle: "italic",
-            fontSize: 12,
-            lineHeight: 1.4,
-            color: "var(--color-ink-muted)",
-          }}
-        >
-          {photo.caption}
-        </figcaption>
-      )}
+      {photo.caption && <figcaption className="t-caption">{photo.caption}</figcaption>}
     </figure>
   );
 }
@@ -403,16 +386,7 @@ export default function ProjectDetailClient({ project }: { project: ProjectEntry
         <div className="pd-title-inner">
           <BackLink />
           <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 8 }}>
-            <span
-              style={{
-                fontFamily: "var(--font-display)",
-                fontWeight: 700,
-                fontSize: 12,
-                letterSpacing: "0.08em",
-                textTransform: "uppercase",
-                color: project.color,
-              }}
-            >
+            <span className="t-btn" style={{ textTransform: "uppercase", color: project.color }}>
               {project.kind}
             </span>
             <span
@@ -424,18 +398,7 @@ export default function ProjectDetailClient({ project }: { project: ProjectEntry
                 display: "inline-block",
               }}
             />
-            <span
-              style={{
-                fontFamily: "var(--font-body)",
-                fontStyle: "italic",
-                fontSize: 12,
-                letterSpacing: "0.06em",
-                textTransform: "uppercase",
-                color: "var(--color-ink-muted)",
-              }}
-            >
-              {project.year}
-            </span>
+            <span className="t-microlabel">{project.year}</span>
           </div>
           <h1 className="pd-h1">{project.title}</h1>
           {project.blurb && <p className="pd-lede">{project.blurb}</p>}
@@ -462,18 +425,7 @@ export default function ProjectDetailClient({ project }: { project: ProjectEntry
             }}
           >
             <h2 className="pd-gallery-title">Gallery</h2>
-            <span
-              style={{
-                fontFamily: "var(--font-body)",
-                fontStyle: "italic",
-                fontSize: 12,
-                letterSpacing: "0.04em",
-                textTransform: "uppercase",
-                color: "var(--color-ink-muted)",
-              }}
-            >
-              {project.gallery.length} photos
-            </span>
+            <span className="t-microlabel">{project.gallery.length} photos</span>
           </div>
           <div ref={galleryRef} className="pd-gallery-grid">
             {project.gallery.map((photo, i) => (

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -76,69 +76,23 @@ function ProjectCard({ item }: { item: ProjectEntry }) {
             gap: 16,
           }}
         >
-          <h2
-            style={{
-              fontFamily: "var(--font-display)",
-              fontWeight: 700,
-              fontSize: 24,
-              lineHeight: 1,
-              color: "var(--color-ink-true)",
-              letterSpacing: "-0.01em",
-              margin: 0,
-            }}
-          >
+          <h2 className="t-card-title" style={{ margin: 0 }}>
             {item.title}
           </h2>
-          <span
-            style={{
-              fontFamily: "var(--font-body)",
-              fontStyle: "italic",
-              fontSize: 12,
-              color: "var(--color-ink-muted)",
-              textTransform: "uppercase",
-              letterSpacing: "0.06em",
-              whiteSpace: "nowrap",
-            }}
-          >
+          <span className="t-microlabel" style={{ whiteSpace: "nowrap" }}>
             {item.year}
           </span>
         </div>
-        <span
-          style={{
-            fontFamily: "var(--font-body)",
-            fontSize: 12,
-            color: "var(--color-ink-muted)",
-            textTransform: "uppercase",
-            letterSpacing: "0.08em",
-          }}
-        >
-          {item.kind}
-        </span>
+        <span className="t-microlabel">{item.kind}</span>
         {item.blurb && (
-          <p
-            style={{
-              fontFamily: "var(--font-body)",
-              fontSize: 14,
-              lineHeight: 1.55,
-              color: "var(--color-ink)",
-              margin: 0,
-            }}
-          >
+          <p className="t-body" style={{ margin: 0 }}>
             {item.blurb}
           </p>
         )}
         <Link
           href={`/projects/${item.slug}`}
-          className="arrow-link"
-          style={{
-            alignSelf: "flex-start",
-            fontFamily: "var(--font-display)",
-            fontWeight: 700,
-            fontSize: 13,
-            color: "var(--color-ink)",
-            textDecoration: "underline",
-            textUnderlineOffset: 3,
-          }}
+          className="t-btn arrow-link"
+          style={{ alignSelf: "flex-start", textDecoration: "underline", textUnderlineOffset: 3 }}
         >
           View project <span className="arrow-right">→</span>
         </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -75,17 +75,92 @@ h2 {
   font-family: var(--font-display);
   font-optical-sizing: auto;
   font-weight: 700;
-  font-style: normal;
-  font-size: 20px;
-  line-height: 1.4;
+  font-size: 28px;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  color: var(--color-ink-true);
+  margin: 0;
 }
 
 p {
   font-family: var(--font-body);
   font-size: 16px;
-  line-height: 1.5;
+  line-height: 1.65;
   color: var(--color-ink-muted);
   margin: 0;
+}
+
+/* ── Typography primitives ────────────────────────────────── */
+.t-header {
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-weight: 700;
+  font-size: clamp(36px, 6vw, 64px);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--color-ink-true);
+}
+.t-h2 {
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-weight: 700;
+  font-size: 28px;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  color: var(--color-ink-true);
+}
+.t-h3 {
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--color-ink-true);
+}
+.t-card-title {
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--color-ink-true);
+}
+.t-body {
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--color-ink-muted);
+}
+.t-lead {
+  font-family: var(--font-body);
+  font-size: clamp(18px, 1.6vw, 21px);
+  line-height: 1.6;
+  color: var(--color-ink-muted);
+}
+.t-caption {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-ink-muted);
+}
+.t-microlabel {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-ink-muted);
+}
+.t-btn {
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: var(--color-ink);
 }
 
 hgroup {
@@ -128,9 +203,9 @@ hgroup {
 .header-cat {
   font-family: var(--font-display);
   font-optical-sizing: auto;
-  font-weight: 600;
-  font-style: normal;
-  font-size: 14px;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.06em;
   color: var(--color-ink);
 }
 
@@ -168,20 +243,22 @@ hgroup {
 }
 
 .proj-row-year {
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 12px;
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 10px;
   color: var(--color-ink-muted);
-  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
 .proj-row-title {
   font-family: var(--font-display);
+  font-optical-sizing: auto;
   font-weight: 700;
-  font-size: 22px;
-  color: var(--color-ink);
-  line-height: 1.1;
-  letter-spacing: -0.005em;
+  font-size: 24px;
+  color: var(--color-ink-true);
+  line-height: 1;
+  letter-spacing: -0.01em;
   transition: transform 260ms var(--ease-smooth);
   min-width: 0;
   overflow: hidden;
@@ -192,8 +269,8 @@ hgroup {
 .proj-row-kind {
   font-family: var(--font-body);
   font-style: italic;
-  font-size: 12px;
-  letter-spacing: 0.04em;
+  font-size: 10px;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--color-ink-muted);
 }
@@ -208,8 +285,9 @@ hgroup {
 
 .proj-count {
   font-family: var(--font-body);
-  font-size: 12px;
-  letter-spacing: 0.04em;
+  font-style: italic;
+  font-size: 10px;
+  letter-spacing: 0.12em;
   color: var(--color-ink-muted);
   text-transform: uppercase;
 }
@@ -329,9 +407,8 @@ hgroup {
   letter-spacing: 0.12em;
 }
 .ceramics-h1 {
-  /* tighter clamp + max-width vs global h1 */
-  font-size: clamp(36px, 4vw, 56px);
-  line-height: 1.05;
+  font-size: clamp(36px, 6vw, 64px);
+  line-height: 1;
   max-width: 600px;
 }
 .ceramics-bio-p {
@@ -363,11 +440,12 @@ hgroup {
   left: 16px;
   background: rgba(255, 255, 255, 0.92);
   backdrop-filter: blur(8px);
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 12px;
-  letter-spacing: 0.08em;
-  color: var(--color-ink);
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-ink-muted);
   padding: 6px 10px;
   border-radius: 6px;
 }
@@ -381,11 +459,11 @@ hgroup {
 }
 .series-crumb-back {
   font-family: var(--font-display);
+  font-optical-sizing: auto;
   font-weight: 700;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--color-ink-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0.06em;
   text-decoration: none;
 }
 .series-crumb-back:hover {
@@ -493,10 +571,11 @@ hgroup {
 
 .pd-h1 {
   font-family: var(--font-display);
+  font-optical-sizing: auto;
   font-weight: 700;
-  font-size: clamp(36px, 5.5vw, 56px);
+  font-size: clamp(36px, 6vw, 64px);
   letter-spacing: -0.02em;
-  line-height: 1.05;
+  line-height: 1;
   color: var(--color-ink-true);
   margin: 0;
   text-wrap: balance;
@@ -505,7 +584,7 @@ hgroup {
 .pd-lede {
   font-family: var(--font-body);
   font-size: clamp(18px, 1.6vw, 21px);
-  line-height: 1.55;
+  line-height: 1.6;
   color: var(--color-ink-muted);
   margin: 8px 0 0;
   text-wrap: pretty;
@@ -530,9 +609,9 @@ hgroup {
 /* Article body typography */
 .pd-body-p {
   font-family: var(--font-body);
-  font-size: 19px;
-  line-height: 1.7;
-  color: #1b1b1b;
+  font-size: clamp(18px, 1.6vw, 21px);
+  line-height: 1.6;
+  color: var(--color-ink-muted);
   margin: 0;
   text-wrap: pretty;
 }
@@ -549,9 +628,11 @@ hgroup {
 
 .pd-body-h3 {
   font-family: var(--font-display);
+  font-optical-sizing: auto;
   font-weight: 700;
   font-size: 20px;
   line-height: 1.2;
+  letter-spacing: -0.01em;
   color: var(--color-ink-true);
   margin: 12px 0 0;
 }
@@ -567,9 +648,9 @@ hgroup {
 
 .pd-body-li {
   font-family: var(--font-body);
-  font-size: 19px;
+  font-size: clamp(18px, 1.6vw, 21px);
   line-height: 1.6;
-  color: #1b1b1b;
+  color: var(--color-ink-muted);
   display: grid;
   grid-template-columns: 16px 1fr;
   column-gap: 12px;
@@ -689,9 +770,10 @@ hgroup {
   border: 1px solid var(--color-border);
   background: #ffffff;
   font-family: var(--font-display);
+  font-optical-sizing: auto;
   font-weight: 700;
   font-size: 13px;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   color: var(--color-ink);
   text-decoration: none;
   cursor: pointer;
@@ -734,7 +816,7 @@ hgroup {
   }
   .pd-body-p,
   .pd-body-li {
-    font-size: 17px;
+    font-size: clamp(16px, 5vw, 18px);
   }
   .pd-footer {
     flex-direction: column;


### PR DESCRIPTION
## Summary

- Adds 10 canonical type utility classes (`.t-header`, `.t-h2`, `.t-h3`, `.t-card-title`, `.t-body`, `.t-lead`, `.t-caption`, `.t-microlabel`, `.t-btn`) to `globals.css` as the single source of truth
- Normalises all existing CSS class typography values (`.pd-h1`, `.pd-body-p`, `.proj-row-year`, `.header-cat`, `.series-crumb-back`, etc.) to match the canonical tiers
- Replaces ~40 scattered inline `fontFamily`/`fontSize`/`fontWeight` style objects across `SeriesDetailClient.tsx`, `ProjectDetailClient.tsx`, `ceramics/page.tsx`, and `projects/page.tsx` with canonical class names

## Test plan

- [x] `yarn lint` — 0 errors (pre-existing warnings only)
- [x] `yarn format:check` — clean
- [x] `yarn test` — 60/60 passing
- [x] `yarn test:coverage` — all metrics above 85%
- [x] `yarn knip` — no unused files/exports
- [x] `yarn build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)