### PR TITLE
Standardize image preview approach across photography and ceramics

### DIFF
--- a/app/ceramics/page.tsx
+++ b/app/ceramics/page.tsx
@@ -30,7 +30,7 @@ export default function CeramicsLanding() {
         </hgroup>
       </div>
       <section className="ceramics-grid-section">
-        <div className="ceramics-grid">
+        <div className="media-grid">
           {series.map((s, i) => (
             <article key={s.slug} className="ceramics-card">
               <Link href={`/ceramics/${s.slug}`} style={{ display: "block" }}>

--- a/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/app/projects/[slug]/ProjectDetailClient.tsx
@@ -427,7 +427,7 @@ export default function ProjectDetailClient({ project }: { project: ProjectEntry
             <h2 className="pd-gallery-title">Gallery</h2>
             <span className="t-microlabel">{project.gallery.length} photos</span>
           </div>
-          <div ref={galleryRef} className="pd-gallery-grid">
+          <div ref={galleryRef} className="media-grid">
             {project.gallery.map((photo, i) => (
               <GalleryThumb key={i} photo={photo} index={i} color={project.color} />
             ))}

--- a/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/app/projects/[slug]/ProjectDetailClient.tsx
@@ -257,7 +257,7 @@ function GalleryThumb({
               src={photo.src}
               alt={photo.caption || `Photo ${index + 1}`}
               fill
-              sizes="(max-width: 640px) 50vw, 25vw"
+              sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"
               style={{ objectFit: "cover" }}
             />
           </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -25,6 +25,7 @@ function ProjectCardImage({ item }: { item: ProjectEntry }) {
         src={item.cover.src}
         alt={item.title}
         fill
+        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
         style={{ objectFit: "cover" }}
         className="ceramics-card-img"
       />

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -117,7 +117,7 @@ export default function Projects() {
         </hgroup>
       </div>
       <section className="ceramics-grid-section">
-        <div className="ceramics-grid">
+        <div className="media-grid">
           {projects.map((item) => (
             <ProjectCard key={item.slug} item={item} />
           ))}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -538,6 +538,10 @@ hgroup {
     gap: 32px 24px;
     padding-top: 32px;
   }
+  .pd-gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 32px 24px;
+  }
 }
 
 /* ── Project detail ───────────────────────────────────────── */
@@ -746,8 +750,8 @@ hgroup {
 
 .pd-gallery-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 40px 32px;
 }
 
 /* End / footer */
@@ -808,8 +812,8 @@ hgroup {
     gap: 48px 0;
   }
   .pd-gallery-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
+    grid-template-columns: 1fr;
+    gap: 48px 0;
   }
   .pd-body-quote-text {
     font-size: 22px;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -415,13 +415,12 @@ hgroup {
   line-height: 1.6;
 } /* wider leading vs global p */
 .ceramics-grid-section {
-  padding-bottom: 96px;
+  padding: 40px var(--page-gutter) 96px;
 }
-.ceramics-grid {
+.media-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 40px 32px;
-  padding: 40px var(--page-gutter) 0;
 }
 .ceramics-card {
   display: flex;
@@ -533,12 +532,10 @@ hgroup {
     max-width: none;
     padding-top: 0;
   }
-  .ceramics-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 32px 24px;
+  .ceramics-grid-section {
     padding-top: 32px;
   }
-  .pd-gallery-grid {
+  .media-grid {
     grid-template-columns: repeat(2, 1fr);
     gap: 32px 24px;
   }
@@ -748,12 +745,6 @@ hgroup {
   line-height: 1.15;
 }
 
-.pd-gallery-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 40px 32px;
-}
-
 /* End / footer */
 .pd-end-section {
   padding: 16px clamp(20px, 6vw, 96px) 48px;
@@ -807,11 +798,7 @@ hgroup {
 }
 
 @media (max-width: 640px) {
-  .ceramics-grid {
-    grid-template-columns: 1fr;
-    gap: 48px 0;
-  }
-  .pd-gallery-grid {
+  .media-grid {
     grid-template-columns: 1fr;
     gap: 48px 0;
   }


### PR DESCRIPTION
The photography gallery was using an auto-fill grid (minmax 220px) and a
25vw sizes hint, producing very small thumbnails. Align it with the ceramics
landing page: explicit 3-column grid with matching responsive breakpoints
(2 cols at 768px, 1 col at 640px) and accurate sizes hints so Next.js
serves full-quality images at the rendered size. Also adds the missing
sizes attribute to project card cover images on the projects landing page.

https://claude.ai/code/session_01DwQoPgbQXWejT9ogHxToeY