### PR TITLE
Add alt text to LinkBox images for accessibility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,8 +31,12 @@ export default function Home() {
             </hgroup>
           </div>
           <div className="flex-initial lg:flex-1 flex gap-4 sm:flex-row flex-wrap content-center justify-center rounded">
-            <LinkBox link="https://www.linkedin.com/in/andrewcgraves/" imgSrc={linkedInLogo} />
-            <LinkBox link="https://github.com/andrewcgraves" imgSrc={githubLogo} />
+            <LinkBox
+              link="https://www.linkedin.com/in/andrewcgraves/"
+              imgSrc={linkedInLogo}
+              alt="LinkedIn"
+            />
+            <LinkBox link="https://github.com/andrewcgraves" imgSrc={githubLogo} alt="GitHub" />
           </div>
         </div>
       </main>

--- a/src/Components/LinkBox.jsx
+++ b/src/Components/LinkBox.jsx
@@ -1,10 +1,10 @@
 import Image from "next/image";
 
-export default function LinkBox({ link, imgSrc }) {
+export default function LinkBox({ link, imgSrc, alt }) {
   return (
     <a href={link} target="_blank" className="object-contain aspect-square flex-none h-24">
       <div className="link-box">
-        <Image src={imgSrc} />
+        <Image src={imgSrc} alt={alt} />
       </div>
     </a>
   );


### PR DESCRIPTION
## Summary
Added `alt` prop to the `LinkBox` component to provide descriptive alt text for images, improving accessibility and SEO.

## Changes
- Updated `LinkBox` component to accept and use an `alt` prop for the `Image` component
- Added `alt="LinkedIn"` to the LinkedIn LinkBox in the home page
- Added `alt="GitHub"` to the GitHub LinkBox in the home page
- Reformatted the LinkedIn LinkBox props for better readability

## Details
The `Image` component from Next.js requires an `alt` attribute for proper accessibility. This change ensures all images have descriptive alt text that screen readers can use, while also following Next.js best practices for image optimization.

https://claude.ai/code/session_01M67wFXzH11uxVo9ycJ2CZW