### PR TITLE
fix: show embedded images at natural aspect ratio

### DIFF
--- a/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/app/projects/[slug]/ProjectDetailClient.tsx
@@ -101,8 +101,10 @@ function ProjectBody({ content, color }: { content: string; color: string }) {
       remarkPlugins={[remarkGfm]}
       components={{
         p: ({ children, node }) => {
-          const onlyChild = node?.children?.length === 1 && node.children[0];
-          if (onlyChild && onlyChild.type === "element" && onlyChild.tagName === "img") {
+          const hasImageChild = node?.children?.some(
+            (child) => child.type === "element" && child.tagName === "img"
+          );
+          if (hasImageChild) {
             return <>{children}</>;
           }
           return <p className="pd-body-p">{children}</p>;
@@ -191,15 +193,14 @@ function ProjectBody({ content, color }: { content: string; color: string }) {
                   overflow: "hidden",
                 }}
               >
-                <div style={{ position: "relative", width: "100%", aspectRatio: "16 / 10" }}>
-                  <Image
-                    src={safeSrc}
-                    alt={caption || ""}
-                    fill
-                    style={{ objectFit: "cover" }}
-                    sizes="880px"
-                  />
-                </div>
+                <Image
+                  src={safeSrc}
+                  alt={caption || ""}
+                  width={0}
+                  height={0}
+                  sizes="880px"
+                  style={{ width: "100%", height: "auto", display: "block" }}
+                />
               </a>
               {caption && <figcaption className="pd-body-figcap">{caption}</figcaption>}
             </figure>
@@ -244,23 +245,20 @@ function GalleryThumb({
             transition: "transform 300ms var(--ease-smooth), box-shadow 300ms var(--ease-smooth)",
           }}
         >
-          <div
+          <Image
+            src={photo.src}
+            alt={photo.caption || `Photo ${index + 1}`}
+            width={0}
+            height={0}
+            sizes="(max-width: 640px) 50vw, 25vw"
             style={{
-              position: "relative",
               width: "100%",
-              aspectRatio: "4 / 3",
+              height: "auto",
+              display: "block",
               transform: hover ? "scale(1.04)" : "scale(1)",
               transition: "transform 600ms var(--ease-smooth)",
             }}
-          >
-            <Image
-              src={photo.src}
-              alt={photo.caption || `Photo ${index + 1}`}
-              fill
-              sizes="(max-width: 640px) 50vw, 25vw"
-              style={{ objectFit: "cover" }}
-            />
-          </div>
+          />
         </a>
       ) : (
         <div

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -27,6 +27,7 @@ function ProjectCardImage({ item }: { item: ProjectEntry }) {
         fill
         style={{ objectFit: "cover" }}
         className="ceramics-card-img"
+        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
       />
     );
   }


### PR DESCRIPTION
## Summary

- Replace fixed `aspectRatio` containers on gallery thumbnails (`4/3`) and body images (`16/10`) with Next.js natural sizing (`width={0} height={0}`, `width: 100%; height: auto`) so images display at their true proportions instead of being cropped
- Fix hydration error where multi-image markdown paragraphs (e.g. three consecutive images without a blank line between them) placed `<figure>` elements inside `<p>`, causing an invalid HTML structure
- Add missing `sizes` prop to project card cover images using `fill`

## Test plan

- [x] Visit a project detail page and confirm gallery thumbnails render at their natural aspect ratio (no cropping)
- [x] Click a gallery thumbnail and confirm the lightbox matches what was shown in the thumbnail
- [x] Visit `/projects/electrolink-paper` and confirm no hydration errors in the console
- [x] Confirm the three thumbnail sketch images render correctly as individual figures
- [x] Visit `/projects` and confirm no `fill` + missing `sizes` console warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)