### PR TITLE
Fix PhotoSwipe gallery dimensions to use hardcoded values

### DIFF
--- a/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/app/projects/[slug]/ProjectDetailClient.tsx
@@ -233,8 +233,8 @@ function GalleryThumb({
         <a
           className="pswp-gallery-item"
           href={photo.src}
-          data-pswp-width={photo.width || 0}
-          data-pswp-height={photo.height || 0}
+          data-pswp-width={0}
+          data-pswp-height={0}
           style={{
             display: "block",
             borderRadius: 10,


### PR DESCRIPTION
## Summary
Updated the PhotoSwipe gallery thumbnail component to use hardcoded dimension values instead of relying on photo metadata.

## Changes
- Changed `data-pswp-width` attribute from `photo.width || 0` to hardcoded `0`
- Changed `data-pswp-height` attribute from `photo.height || 0` to hardcoded `0`

## Implementation Details
This change modifies how PhotoSwipe calculates gallery item dimensions. Previously, the component attempted to use actual photo dimensions from the `photo` object with a fallback to `0`. Now both dimensions are explicitly set to `0`, which may indicate:
- A shift to letting PhotoSwipe calculate dimensions dynamically from the DOM
- A temporary fix for dimension-related issues
- A change in how the gallery should handle responsive sizing

The hardcoded values suggest this may be part of a larger refactoring of the gallery's dimension handling logic.

https://claude.ai/code/session_01Uk4MwMbnbCtd5zu2sLyB6P